### PR TITLE
RF: allow ipython notebook filenames with spaces

### DIFF
--- a/notebook_sphinxext.py
+++ b/notebook_sphinxext.py
@@ -16,6 +16,12 @@ class NotebookDirective(Directive):
     final_argument_whitespace = True
 
     def run(self):
+        # check if there are spaces in the notebook name
+        nb_path = self.arguments[0]
+        if ' ' in nb_path:
+            raise ValueError(
+                "Cannot have spaces in notebook file name '{0}'".format(
+                    nb_path))
         # check if raw html is supported
         if not self.state.document.settings.raw_enabled:
             raise self.warning('"%s" directive disabled.' % self.name)
@@ -23,7 +29,7 @@ class NotebookDirective(Directive):
         # get path to notebook
         source_dir = os.path.dirname(
             os.path.abspath(self.state.document.current_source))
-        nb_basename = os.path.basename(self.arguments[0])
+        nb_basename = os.path.basename(nb_path)
         rst_file = self.state_machine.document.attributes['source']
         rst_dir = os.path.abspath(os.path.dirname(rst_file))
         nb_abs_path = os.path.join(rst_dir, nb_basename)


### PR DESCRIPTION
sphinx directives need `final_argument_whitespace=True` in order for the final
argument to a directive to contain whitespace. So, we need to set this to
allow spaces in the ipython notebook filename.  Spaces are fairly common in
notebook filenames because the filename doubles as the title.
