### PR TITLE
Enable relative paths for notebooks

### DIFF
--- a/notebook_sphinxext.py
+++ b/notebook_sphinxext.py
@@ -22,10 +22,11 @@ class NotebookDirective(Directive):
         # get path to notebook
         source_dir = os.path.dirname(
             os.path.abspath(self.state.document.current_source))
-        nb_basename = os.path.basename(self.arguments[0])
+        nb_filename = self.arguments[0]
+        nb_basename = os.path.basename(nb_filename)
         rst_file = self.state_machine.document.attributes['source']
         rst_dir = os.path.abspath(os.path.dirname(rst_file))
-        nb_abs_path = os.path.join(rst_dir, nb_basename)
+        nb_abs_path = os.path.abspath(os.path.join(rst_dir, nb_filename))
 
         # Move files around.
         rel_dir = os.path.relpath(rst_dir, setup.confdir)


### PR DESCRIPTION
Specifically, this enables usage like:

```
.. notebook:: ../notebooks/blah.ipynb
```

for notebooks that are in a separate directory relative to one's
rst source.

Thanks for maintaining this utility--after far too much time spent fussing with nbconvert (which is otherwise highly useful) this gave me almost exactly the results I was after from the start.
