### PR TITLE
Template option - add a config option to output a basic template vs a full html document

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,27 +10,31 @@ Install it using pip:
 
 Add the extension to your `conf.py`:
 
-    extensions = [
-        # Import both
-        'RunNotebook',
-        
-        # or import each directive individually
-        # 'RunNotebook.notebook_sphinxext',
-        # 'RunNotebook.notebookcell_sphinxext',
-        # ...
-    ]
+```python
+extensions = [
+    # Import both
+    'RunNotebook',
+    
+    # or import each directive individually
+    # 'RunNotebook.notebook_sphinxext',
+    # 'RunNotebook.notebookcell_sphinxext',
+    # ...
+]
+```
 
 Optional configuration in your `conf.py`:
 
-    # Run notebook configuration
+```python
+# Run notebook configuration
 
-    # The template used when exporting from nbconvert
-    #   full  - Outputs the full HTML document [Default]
-    #   basic - Outputs a single div (with no additional resources)
-    run_notebook_export_template = 'basic'  # Default: 'full'
+# The template used when exporting from nbconvert
+#   full  - Outputs the full HTML document [Default]
+#   basic - Outputs a single div (with no additional resources)
+run_notebook_export_template = 'basic'  # Default: 'full'
 
-    # Display the source links to the generated evaluated files
-    run_notebook_display_source_links = False  # Default: True
+# Display the source links to the generated evaluated files
+run_notebook_display_source_links = False  # Default: True
+```
 
 Take a look at the `conf.py` file in the example sphinx project to see how to 
 integrate with your sphinx build.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,30 @@ This package is available on pypi: https://pypi.python.org/pypi/RunNotebook
 
 Install it using pip:
 
-    $ pip install RunNotebook
+    pip install RunNotebook
+
+Add the extension to your `conf.py`:
+
+    extensions = [
+        # Import both
+        'RunNotebook',
+        
+        # or import each directive individually
+        # 'RunNotebook.notebook_sphinxext',
+        # 'RunNotebook.notebookcell_sphinxext',
+        # ...
+    ]
+
+Optional configuration in your `conf.py`:
+
+    # Run notebook configuration
+
+    # The template used when exporting from nbconvert
+    #
+    # full  - Outputs the full HTML document [Default]
+    # basic - Outputs a single div (with no additional resources)
+    #
+    run_notebook_export_template = 'basic'  # Default: 'full'
 
 Take a look at the `conf.py` file in the example sphinx project to see how to 
 integrate with your sphinx build.

--- a/README.md
+++ b/README.md
@@ -25,11 +25,12 @@ Optional configuration in your `conf.py`:
     # Run notebook configuration
 
     # The template used when exporting from nbconvert
-    #
-    # full  - Outputs the full HTML document [Default]
-    # basic - Outputs a single div (with no additional resources)
-    #
+    #   full  - Outputs the full HTML document [Default]
+    #   basic - Outputs a single div (with no additional resources)
     run_notebook_export_template = 'basic'  # Default: 'full'
+
+    # Display the source links to the generated evaluated files
+    run_notebook_display_source_links = False  # Default: True
 
 Take a look at the `conf.py` file in the example sphinx project to see how to 
 integrate with your sphinx build.

--- a/RunNotebook/__init__.py
+++ b/RunNotebook/__init__.py
@@ -1,2 +1,7 @@
 from . import notebook_sphinxext
 from . import notebookcell_sphinxext
+
+
+def setup(app):
+    notebook_sphinxext.setup(app)
+    notebookcell_sphinxext.setup(app)

--- a/RunNotebook/notebook_sphinxext.py
+++ b/RunNotebook/notebook_sphinxext.py
@@ -78,13 +78,14 @@ class NotebookDirective(Directive):
             resources, image_dir, image_rel_dir, evaluated_text)
 
         # Create link to notebook and script files
-        link_rst = "(" + \
-                   formatted_link(nb_basename) + "; " + \
-                   formatted_link(rel_path_eval) + "; " + \
-                   formatted_link(rel_path_script) + \
-                   ")"
+        if setup.config.run_notebook_display_source_links:
+            link_rst = "(" + \
+                       formatted_link(nb_basename) + "; " + \
+                       formatted_link(rel_path_eval) + "; " + \
+                       formatted_link(rel_path_script) + \
+                       ")"
 
-        self.state_machine.insert_input([link_rst], rst_file)
+            self.state_machine.insert_input([link_rst], rst_file)
 
         # create notebook node
         attributes = {'format': 'html', 'source': 'nb_path'}
@@ -207,6 +208,8 @@ def setup(app):
     setup.confdir = app.confdir
 
     app.add_config_value('run_notebook_export_template', 'full',
+                         rebuild='html')
+    app.add_config_value('run_notebook_display_source_links', True,
                          rebuild='html')
 
     app.add_node(notebook_node,

--- a/RunNotebook/notebook_sphinxext.py
+++ b/RunNotebook/notebook_sphinxext.py
@@ -131,49 +131,53 @@ def nb_to_html(nb_path, skip_exceptions):
     if skip_exceptions is False:
         nbconvert_config_nb['ExecutePreprocessor']['allow_errors'] = True
 
+    template = setup.config.run_notebook_export_template
+
     hexporter = html.HTMLExporter(
-        template_file='full', config=nbconvert_config_html)
+        template_file=template, config=nbconvert_config_html)
     nexporter = notebook_exporter.NotebookExporter(config=nbconvert_config_nb)
     notebook = nbformat.read(nb_path, nbformat.NO_CONVERT)
     noutput, _ = nexporter.from_notebook_node(notebook)
     eval_notebook = nbformat.reads(noutput, nbformat.NO_CONVERT)
     houtput, hresources = hexporter.from_notebook_node(eval_notebook)
-    header = houtput.split('<head>', 1)[1].split('</head>', 1)[0]
-    body = houtput.split('<body>', 1)[1].split('</body>', 1)[0]
 
-    # http://imgur.com/eR9bMRH
-    header = header.replace('<style', '<style scoped="scoped"')
-    header = header.replace(
-        'body {\n  overflow: visible;\n  padding: 8px;\n}\n', '')
-    header = header.replace("code,pre{", "code{")
+    if template == 'basic':
+        header_lines = []
+        body = houtput
+    else:
+        header = houtput.split('<head>', 1)[1].split('</head>', 1)[0]
+        body = houtput.split('<body>', 1)[1].split('</body>', 1)[0]
 
-    # Filter out styles that conflict with the sphinx theme.
-    filter_strings = [
-        'navbar',
-        'body{',
-        'alert{',
-        'uneditable-input{',
-        'collapse{',
-    ]
+        # http://imgur.com/eR9bMRH
+        header = header.replace('<style', '<style scoped="scoped"')
+        header = header.replace(
+            'body {\n  overflow: visible;\n  padding: 8px;\n}\n', '')
+        header = header.replace("code,pre{", "code{")
 
-    line_begin = [
-        'pre{',
-        'p{margin'
-    ]
+        # Filter out styles that conflict with the sphinx theme.
+        filter_strings = [
+            'navbar',
+            'body{',
+            'alert{',
+            'uneditable-input{',
+            'collapse{',
+        ]
 
-    filterfunc = lambda x: not any([s in x for s in filter_strings])
-    header_lines = filter(filterfunc, header.split('\n'))
+        line_begin = [
+            'pre{',
+            'p{margin'
+        ]
 
-    filterfunc = lambda x: not any([x.startswith(s) for s in line_begin])
-    header_lines = filter(filterfunc, header_lines)
+        filterfunc = lambda x: not any([s in x for s in filter_strings])
+        header_lines = filter(filterfunc, header.split('\n'))
+
+        filterfunc = lambda x: not any([x.startswith(s) for s in line_begin])
+        header_lines = filter(filterfunc, header_lines)
 
     header = '\n'.join(header_lines)
 
     # concatenate raw html lines
-    lines = ['<div class="ipynotebook">']
-    lines.append(header)
-    lines.append(body)
-    lines.append('</div>')
+    lines = ['<div class="ipynotebook">', header, body, '</div>']
     return '\n'.join(lines), hresources, noutput
 
 
@@ -202,8 +206,12 @@ def setup(app):
     setup.config = app.config
     setup.confdir = app.confdir
 
+    app.add_config_value('run_notebook_export_template', 'full',
+                         rebuild='html')
+
     app.add_node(notebook_node,
-                 html=(visit_notebook_node, depart_notebook_node))
+                 html=(visit_notebook_node, depart_notebook_node),
+                 override=True)
 
     app.add_directive('notebook', NotebookDirective)
 

--- a/RunNotebook/notebookcell_sphinxext.py
+++ b/RunNotebook/notebookcell_sphinxext.py
@@ -63,13 +63,15 @@ class NotebookCellDirective(Directive):
 
         return [nb_node]
 
+
 def setup(app):
     setup.app = app
     setup.config = app.config
     setup.confdir = app.confdir
 
     app.add_node(notebook_node,
-                 html=(visit_notebook_node, depart_notebook_node))
+                 html=(visit_notebook_node, depart_notebook_node),
+                 override=True)
 
     app.add_directive('notebook-cell', NotebookCellDirective)
 


### PR DESCRIPTION
Hi,

These are awesome directives, thanks!

`README.md` - Make pip command easy copy and paste (remove $), and add setup instructions and example configuration options.

`__init__.py` - I added the setup method so we can import both directives via `RunNotebook`.

`override=True` - I added this to `add_node` to remove the Warning message thrown by sphinx (overriding existing node) - when importing both directives.

`run_notebook_export_template` - I use a custom template with sphinx, so I don't need all the bootstrap css and js that comes with the export. By passing `basic` we are returned a simple div which can be embedded into a blog providing it's own css styles. - It works great!

`run_notebook_display_source_links` - I wanted to hide the source links and just show the notebook output, setting this to `False` will hide the links, if the configuration option is not provided they will be shown by default.